### PR TITLE
chore: move jwt secret to env var

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,7 +8,7 @@ import { UsersModule } from 'users/users.module'
 import { LocalStrategy } from './local.strategy'
 import { PassportModule } from '@nestjs/passport'
 import { JwtModule } from '@nestjs/jwt'
-import { jwtConstants } from './constants'
+import { ConfigService } from 'config/config.service'
 
 @Module({
   imports: [
@@ -17,9 +17,13 @@ import { jwtConstants } from './constants'
     MailerModule,
     UsersModule,
     PassportModule,
-    JwtModule.register({
-      secret: jwtConstants.secret,
-      signOptions: { expiresIn: '1y' },
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get('jwt.secret'),
+        signOptions: { expiresIn: '1y' },
+      }),
     }),
   ],
   controllers: [AuthController],

--- a/backend/src/auth/constants.ts
+++ b/backend/src/auth/constants.ts
@@ -1,4 +1,0 @@
-// TODO move this to env var
-export const jwtConstants = {
-  secret: 'secretKey',
-}

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,15 +1,15 @@
 import { ExtractJwt, Strategy } from 'passport-jwt'
 import { PassportStrategy } from '@nestjs/passport'
 import { Injectable } from '@nestjs/common'
-import { jwtConstants } from './constants'
+import { ConfigService } from 'config/config.service'
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private config: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: jwtConstants.secret,
+      secretOrKey: config.get('jwt.secret'),
     })
   }
 

--- a/backend/src/config/config.schema.ts
+++ b/backend/src/config/config.schema.ts
@@ -19,6 +19,7 @@ export interface ConfigSchema {
     database: string
   }
   health: { heapSizeThreshold: number; rssThreshold: number }
+  jwt: { secret: string }
 }
 
 /**
@@ -156,6 +157,14 @@ export const schema: Schema<ConfigSchema> = {
       format: 'int',
       // TODO: Set to a more reasonable value depending on the instance size used.
       default: 3000 * 1024 * 1024, // 3000MB
+    },
+  },
+  jwt: {
+    secret: {
+      doc: 'jwt secret used to generate login jwts',
+      env: 'SPOTLIGHTSG_APP_JWT_SECRET',
+      default: 'secretKey',
+      format: String,
     },
   },
 }


### PR DESCRIPTION
jwts were hardcoded in a constant file. 

They are now moved to the config file which uses an env variable.
