### PR TITLE
feat: add canManage field to posts

### DIFF
--- a/backend/src/database/models/post.ts
+++ b/backend/src/database/models/post.ts
@@ -11,8 +11,27 @@ import {
 } from 'sequelize-typescript'
 import { User, Comment, Follow } from '.'
 
+export type PostAttributes = {
+  id: number
+  userId: number
+  title: string
+  issue: string
+  actionsTaken: string
+  user: User
+  comments: Comment[]
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type PostCreationAttributes = {
+  userId: number
+  title: string
+  issue: string
+  actionsTaken: string
+}
+
 @Table({ tableName: 'posts' })
-export class Post extends Model {
+export class Post extends Model<PostAttributes, PostCreationAttributes> {
   @Column({
     primaryKey: true,
     type: DataType.INTEGER,

--- a/backend/src/posts/posts.controller.ts
+++ b/backend/src/posts/posts.controller.ts
@@ -14,8 +14,8 @@ import { PostsService } from './posts.service'
 import { CreatePostDto } from './dto/create-post.dto'
 import { IsNumberStringValidator } from '../helper/isNumberStringValidator'
 import {
-  PostStrippedWithCommentsCountAndUserEmailDomain,
-  PostStrippedWithUserEmailDomainAndComment,
+  PostStrippedWithCommentsCountAndUserEmailDomainAndAccess,
+  PostStrippedWithUserEmailDomainAndCommentAndAccess,
 } from './types'
 
 @Controller('posts')
@@ -23,15 +23,21 @@ export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Get()
-  async getAll(): Promise<PostStrippedWithCommentsCountAndUserEmailDomain[]> {
-    return this.postsService.getAllAndMaskEmail()
+  async getAll(
+    @Req() req: Request
+  ): Promise<PostStrippedWithCommentsCountAndUserEmailDomainAndAccess[]> {
+    return this.postsService.getAllAndMaskEmail(req.user!)
   }
 
   @Get(':id')
   async getWithComments(
+    @Req() req: Request,
     @Param() param: IsNumberStringValidator
-  ): Promise<PostStrippedWithUserEmailDomainAndComment> {
-    const post = await this.postsService.getUsingPostIdAndMaskEmail(param.id)
+  ): Promise<PostStrippedWithUserEmailDomainAndCommentAndAccess> {
+    const post = await this.postsService.getUsingPostIdAndMaskEmail(
+      param.id,
+      req.user!
+    )
     if (!post) throw new NotFoundException()
     return post
   }

--- a/backend/src/posts/posts.service.ts
+++ b/backend/src/posts/posts.service.ts
@@ -118,7 +118,7 @@ export class PostsService {
             updatedAt: comment.updatedAt,
           } as CommentWithUser
         }),
-        canManage: user.email === post.user.email,
+        canManage: user.id === post.user.id,
       }
     }
     return post

--- a/backend/src/posts/posts.service.ts
+++ b/backend/src/posts/posts.service.ts
@@ -32,7 +32,6 @@ export class PostsService {
       include: [
         {
           model: User,
-          attributes: ['email'],
         },
         {
           model: Comment,
@@ -69,7 +68,7 @@ export class PostsService {
         updatedAt: post.updatedAt,
         user: this.maskEmail(post.user),
         commentsCount: post.commentsCount,
-        canManage: user.email === post.user.email,
+        canManage: user.id === post.user.id,
       }
     })
   }
@@ -80,7 +79,6 @@ export class PostsService {
       include: [
         {
           model: User,
-          attributes: ['email'],
         },
         {
           model: Comment,

--- a/backend/src/posts/types/index.ts
+++ b/backend/src/posts/types/index.ts
@@ -13,12 +13,15 @@ export type PostStrippedWithCommentsCountAndOriginalUser =
     user: User
   }
 
-export type PostStrippedWithCommentsCountAndUserEmailDomain =
+export type PostStrippedWithCommentsCountAndUserEmailDomainAndAccess =
   PostStrippedWithCommentsCount & {
     user: UserEmailDomain
+    canManage: boolean
   }
 
-export type PostStrippedWithUserEmailDomainAndComment = PostStripped & {
-  user: UserEmailDomain
-  comments: CommentWithUser[]
-}
+export type PostStrippedWithUserEmailDomainAndCommentAndAccess =
+  PostStripped & {
+    user: UserEmailDomain
+    comments: CommentWithUser[]
+    canManage: boolean
+  }

--- a/backend/src/posts/types/index.ts
+++ b/backend/src/posts/types/index.ts
@@ -1,8 +1,8 @@
 import { UserEmailDomain } from 'auth/types'
 import { CommentWithUser } from 'comments/types'
-import { User, Post } from 'database/models'
+import { User, PostAttributes } from 'database/models'
 
-export type PostStripped = Omit<Post, 'userId' | 'comments'>
+export type PostStripped = Omit<PostAttributes, 'userId' | 'comments' | 'user'>
 
 export type PostStrippedWithCommentsCount = PostStripped & {
   commentsCount: number

--- a/frontend/src/components/Post/Post.tsx
+++ b/frontend/src/components/Post/Post.tsx
@@ -76,7 +76,7 @@ const Post: React.FC<PostProps> = ({ id }) => {
             </Box>
             <FollowButton isFollowing={false} />
           </Flex>
-          {auth?.user.email === postWithComments.user.emailDomain && (
+          {postWithComments.canManage && (
             <>
               <HStack pt="20px">
                 <Button

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -80,7 +80,7 @@ const Landing = (): JSX.Element => {
               previewText={post.issue}
               email={post.user.emailDomain}
               commentsCount={post.commentsCount}
-              canManage={false}
+              canManage={post.canManage}
             />
           ))}
         </SimpleGrid>

--- a/frontend/src/services/types.tsx
+++ b/frontend/src/services/types.tsx
@@ -19,6 +19,7 @@ export type Post = {
   user: {
     emailDomain: string
   }
+  canManage: boolean
 }
 
 type Comment = {


### PR DESCRIPTION
Add a `canManage` field to the backend posts, and frontend to show the edit/delete button only if access is true